### PR TITLE
more hero abilities

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -28,6 +28,7 @@ class Bot(BotCore):
         current_round = -1
         ability_one_timer = time.time()
         ability_two_timer = time.time()
+        ability_three_timer = time.time()
         
         finished = False
 
@@ -73,14 +74,22 @@ class Bot(BotCore):
 
             if current_round != None:
                 # Saftey net; use abilites
-                # TODO: Make this more general to support more gameplans
-                if current_round >= 39 and self.abilityAvaliabe(ability_one_timer, 35):
-                    self.press_key("1")
-                    ability_one_timer = time.time()
-                
-                if current_round >= 51 and self.abilityAvaliabe(ability_two_timer, 90):
-                    self.press_key("2")
-                    ability_two_timer = time.time()
+                # TODO: Calculate round dynamically, base on which round hero has been placed.
+                if self.settings["HERO"] != "GERALDO": # geraldo doesn't any ability
+                    cooldowns = static.hero_cooldowns[self.settings["HERO"]]
+
+                    if current_round >= 7 and self.abilityAvaliabe(ability_one_timer, cooldowns[0]):
+                        self.press_key("1")
+                        ability_one_timer = time.time()
+                    
+                    # skip if ezili or adora, their lvl 7 ability is useless
+                    if current_round >= 31 and self.abilityAvaliabe(ability_two_timer, cooldowns[1]) and (self.settings["HERO"] != "EZILI" and "ADORA"):
+                        self.press_key("2")
+                        ability_two_timer = time.time()
+
+                    if current_round >= 53 and self.abilityAvaliabe(ability_three_timer, cooldowns[2]) and len(cooldowns) == 3:
+                        self.press_key("3")
+                        ability_three_timer = time.time()
 
                 # Check for round in game plan
                 if str(current_round) in self.game_plan:

--- a/static.py
+++ b/static.py
@@ -60,6 +60,24 @@ hero_positions = {
     "GERALDO"           : [ 0.11953125 , 0.36944444444444446 ]
 }
 
+#   "HERO"              : [1, 2, 3]         cooldown changes with level-ups..............           notes
+hero_cooldowns = {
+    "QUINCY"            : [60, 70],         # L15 [45,70]     L18 [45,55]
+    "GWENDOLIN"         : [40, 60],         
+    "STRIKER_JONES"     : [16, 80],         # L15 [11,80]
+    "OBYN"              : [35, 90],         
+    "CAPTAIN_CHURCHILL" : [30, 60],         # L20 [30,30]
+    "BENJAMIN"          : [30, 65],         
+    "EZILI"             : [60, 90, 60],     # L12 [45,90,60]  L20 [45,90,40]                        2n ability useless???
+    "PAT_FUSTY"         : [45, 20],         
+    "ADORA"             : [45, 10, 60],     #                                                       2n ability useless???
+    "ADMIRAL_BRICKELL"  : [50, 60, 60],     # L13 [50,60,50]  L18 [50,60,40]
+    "ETIENNE"           : [70, 90],         # L6 [55,90]      L13 [55,75]       L16 [50,75]
+    "SAUDA"             : [30, 45],         
+    "PSI"               : [40, 60],         
+    "GERALDO"           : []                
+}
+
 tower_keybinds = {
     "DART" : "q",
     "BOOMERANG" : "w",


### PR DESCRIPTION
#44
We can calculate how much xp the hero has given the round we are in and the round he was placed on.
We already have this infos in the bot.

If we do so we can dinamically calculate on which round each ability will be unlocked and we can also update the cooldowns, many abilties have reduced cooldowns at certain hero levels.

static.py could be changed in something like this example with quincy:

```python
"QUICY" : {
    #xp : [cooldowns]
    640 : [60], # 1st ability unlocked
    43280 : [60,70], # 2nd ability unlocked
    122030 : [45,70], # lvl 15 1st ability improved cooldown
    179810 : [45,55] # lvl 18 2nd ability improved cooldown
}
```